### PR TITLE
Fix errors due to fasta headers with additional fields

### DIFF
--- a/SLaPMapper.pl
+++ b/SLaPMapper.pl
@@ -750,7 +750,7 @@ sub SlurpFasta	{
 				while (<FILE>)
 					{
 					my $l = $_;
-					if ($l =~ m/>(.+)\n/)
+					if ($l =~ m/^>(\S+)/)
 						{
 						$next = $1;
 						if ($i == 0)

--- a/SLaPMapper.pl
+++ b/SLaPMapper.pl
@@ -280,7 +280,7 @@ sub read_splice_sam_file	{
 									my $ml = $1;
 									if (($ml == $len)&&($mapq > 0))
 										{
-										if ($t[1] == 0)
+										if (!($t[1] & 16))
 											{									
 											my $s2 = substr ($seqs{$t[2]}, $t[3] - 1 - $alen, $alen);	
 											my $s3 = substr ($seqs{$t[2]}, $t[3] - 3, 2);							


### PR DESCRIPTION
This PR fixes reading of fasta files with header / title lines containing more than just the sequence name, i.e.:
```
>sequence_name | organism=Paddington_bear | version=1970-01-01 | length=10000 | SO=chromosome
```

It also fixes a potential bug where the SAM reverse sequence bit int the FLAG field is checked by direct comparison (i.e. `FLAGS==16`) instead of a logical and (i.e. `FLAGS & 16`).